### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,9 +47,9 @@ If you have any questions just [email me](mailto:vkasci@gmail.com). Feel free to
 
 <a name="cocoapods"/>
 
-### Cocoapods
+### CocoaPods
 
-To install all project dependencies just use Cocoapods:
+To install all project dependencies just use CocoaPods:
 
 ```bash
 pod install


### PR DESCRIPTION

This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).
